### PR TITLE
Readme: add a note suggesting people use Gitpod/Codespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ This repository contains the source to build a Debian package for [alacritty](ht
 
 ## Usage
 
-If you have [Docker](https://www.docker.com/) installed locally, just run the following:
+If you have [Docker](https://www.docker.com/) installed
+(locally, on [Gitpod](https://gitpod.io/#https://github.com/barnumbirr/alacritty-debian),
+or on a [Codespace](https://codespaces.new/barnumbirr/alacritty-debian)), just run the following:
 
 ```bash
 user@hostname$ ./build.sh


### PR DESCRIPTION
I don't have docker installed locally, but I found that making the `deb` file for
the new 0.12.1 Alacritty via Gitpod/Codespace is very easy.

Also, thank you very much for maintaining this!